### PR TITLE
Fixing startup bug with latest versions of Spigot.

### DIFF
--- a/src/me/mjolnir/mineconomy/MineConomy.java
+++ b/src/me/mjolnir/mineconomy/MineConomy.java
@@ -415,7 +415,7 @@ public class MineConomy extends JavaPlugin
     private static void load()
     {
         Settings.load();
-        MCCom.initialize(this);
+        MCCom.initialize();
         MCCom.getAccounting().load();
         Banking.load();
         Currency.load();

--- a/src/me/mjolnir/mineconomy/MineConomy.java
+++ b/src/me/mjolnir/mineconomy/MineConomy.java
@@ -415,7 +415,7 @@ public class MineConomy extends JavaPlugin
     private static void load()
     {
         Settings.load();
-        MCCom.initialize();
+        MCCom.initialize(this);
         MCCom.getAccounting().load();
         Banking.load();
         Currency.load();

--- a/src/me/mjolnir/mineconomy/internal/MCCom.java
+++ b/src/me/mjolnir/mineconomy/internal/MCCom.java
@@ -24,7 +24,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class MCCom
 {
-	private static MineConomy	plugin	= new MineConomy();
+	private static MineConomy	plugin;
 	private static AccountingBase accounting = null;
 
 	/**
@@ -1287,8 +1287,9 @@ public class MCCom
 	/**
 	 * Initializes MCCom base classes. (Required for SQL)
 	 */
-	public static void initialize()
+	public static void initialize(MineConomy plugin)
     {
+    	this.plugin = plugin;
 	    if (Settings.dbtype.equalsIgnoreCase("mysql"))
 	    {
 	        IOH.log("MySQL is enabled for Accounts.", IOH.INFO);

--- a/src/me/mjolnir/mineconomy/internal/MCCom.java
+++ b/src/me/mjolnir/mineconomy/internal/MCCom.java
@@ -24,7 +24,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class MCCom
 {
-	private static MineConomy	plugin;
+	public static MineConomy	plugin;
 	private static AccountingBase accounting = null;
 
 	/**
@@ -1287,9 +1287,9 @@ public class MCCom
 	/**
 	 * Initializes MCCom base classes. (Required for SQL)
 	 */
-	public static void initialize(MineConomy plugin)
+	public static void initialize()
     {
-    	this.plugin = plugin;
+            MCCom.plugin = MineConomy.plugin;
 	    if (Settings.dbtype.equalsIgnoreCase("mysql"))
 	    {
 	        IOH.log("MySQL is enabled for Accounts.", IOH.INFO);


### PR DESCRIPTION
This should fix startup errors with Spigot. You should never re-initialize your main class; this is one on line 27 of your MCCom.java file which causes issues with loading the plugin on the latest versions of spigot however it shouldn't have worked at all.
